### PR TITLE
W-13484331-apikeysonlyvisibleoncreation-se

### DIFF
--- a/rpa-manager/modules/ROOT/nav.adoc
+++ b/rpa-manager/modules/ROOT/nav.adoc
@@ -5,7 +5,7 @@
 * xref:usermanagement-overview.adoc[User Management]
 ** xref:usermanagement-manage.adoc[Managing Users]
 ** xref:usermanagement-assemble.adoc[Assembling User Groups]
-** xref:usermanagement-connect.adoc[Connecting from other Salesforce products]
+** xref:usermanagement-connect.adoc[Connecting RPA Processes from Salesforce Products]
 * xref:botmanagement-overview.adoc[Bot Management]
 ** xref:botmanagement-support.adoc[Supporting Bots]
 ** xref:botmanagement-know.adoc[Getting to Know Bots]

--- a/rpa-manager/modules/ROOT/nav.adoc
+++ b/rpa-manager/modules/ROOT/nav.adoc
@@ -5,7 +5,7 @@
 * xref:usermanagement-overview.adoc[User Management]
 ** xref:usermanagement-manage.adoc[Managing Users]
 ** xref:usermanagement-assemble.adoc[Assembling User Groups]
-** xref:usermanagement-connect.adoc[Connecting RPA Processes from Salesforce Products]
+** xref:usermanagement-connect.adoc[Connecting to RPA Processes from Salesforce Products]
 * xref:botmanagement-overview.adoc[Bot Management]
 ** xref:botmanagement-support.adoc[Supporting Bots]
 ** xref:botmanagement-know.adoc[Getting to Know Bots]

--- a/rpa-manager/modules/ROOT/nav.adoc
+++ b/rpa-manager/modules/ROOT/nav.adoc
@@ -5,7 +5,7 @@
 * xref:usermanagement-overview.adoc[User Management]
 ** xref:usermanagement-manage.adoc[Managing Users]
 ** xref:usermanagement-assemble.adoc[Assembling User Groups]
-** xref:usermanagement-connect.adoc[Connecting to MuleSoft Composer]
+** xref:usermanagement-connect.adoc[Connecting from other Salesforce products]
 * xref:botmanagement-overview.adoc[Bot Management]
 ** xref:botmanagement-support.adoc[Supporting Bots]
 ** xref:botmanagement-know.adoc[Getting to Know Bots]

--- a/rpa-manager/modules/ROOT/pages/botmanagement-support.adoc
+++ b/rpa-manager/modules/ROOT/pages/botmanagement-support.adoc
@@ -31,8 +31,8 @@ To create an API key:
 
 . Open the *API Key* view of the *Bot Management* module.
 . Click *New API Key*.
-. In the window *Create Bot API Key*, enter a name and description and click *OK*.
-. In the window *Key Created!*, click *Copy to clipboard*.
+. In the *Create Bot API Key* window, enter a name and description and click *OK*.
+. In the *Key Created!* window, click *Copy to clipboard*.
 . Copy the API key to a secure place.
 . Click *Close*.
 
@@ -40,24 +40,24 @@ Copy your saved API key into the configuration settings of the bot during instal
 
 === Edit an API Key
 
-Edit an API key to change its name or description. If you lose an API key, create a new one.
+Edit an API key to change its name or description.
 
 To edit an API key:
 
 . Open the *API Key* view of the *Bot Management* module.
-. Click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the table row of the API key to edit.
-. In the window *Edit Bot API Key*, change name or description and click *OK*.
+. Click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the row of the API key to edit.
+. In the *Edit Bot API Key* window, change the name or description and click *OK*.
 
 === Remove an API Key
 
 Remove API keys you no longer need.
 
-When you delete an API key, the system does not check whether the key is assigned to a bot. If you have deleted an API key that is in use, the bot can no longer connect to RPA Manager until a new API key is assigned.
+When you delete an API key, the system does not check whether the key is assigned to a bot. If you deleted an API key that is in use, the bot can no longer connect to RPA Manager until a new API key is assigned.
 
 To delete an API key:
 
 . Open the *API Key* view of the *Bot Management* module.
-. Click the *Remove* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the table row of the API key to remove.
+. Click the *Remove* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the row of the API key to remove.
 . Confirm the removal.
 
 == Manage Service Times
@@ -87,7 +87,7 @@ The names of the service times do not have to be unique. To avoid misinterpretin
 For example, name your service time `Regular working hours - 9 AM - 5 PM - Mystical University - Buenos Aires (ART (UTC -3))` or  `Low resource usage time - 5 PM - 9AM - Mystical University - Berlin (CET (UTC +1))`.
 
 . In the *Service Times* view of the *Bot Management* module, click *Create*.
-. In the window *Create Service Time*, complete the form:
+. In the *Create Service Time* window, complete the form:
 +
 * *Timezone*: Specify a downtime in the time zone in which it occurs. If the bot that you assign the downtime to is installed on a computer that uses a different time zone, the downtime interval is converted to the bot’s time zone. If you assign the application to multiple bots in different time zones, all bots pause executing processes that use that application simultaneously. The time intervals might change, depending on daylight saving time.
 +
@@ -102,8 +102,8 @@ include::rpa-manager::partial$form-scheduling.adoc[]
 Edit a service time if it has changed.
 If a changed service time is already used by a bot, it is updated automatically there.
 
-. In the *Service Times* view of the *Bot Management* module, click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the table row of the service time to edit.
-. In the window *Edit Service Time*, change the data and click *OK*.
+. In the *Service Times* view of the *Bot Management* module, click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the row of the service time to edit.
+. In the *Edit Service Time* window, change the data and click *OK*.
 
 == Remove a Service Time
 
@@ -111,7 +111,7 @@ Remove service times no longer effective.
 
 The deleted service time is also removed from the service times of a bot. If the deleted service time is the only one that was used by a bot, the bot uses the default service time (24/7).
 
-. In the *Service Times* view of the *Bot Management* module, click the *Remove* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the table row of the service time  to remove.
+. In the *Service Times* view of the *Bot Management* module, click the *Remove* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the row of the service time to remove.
 . Confirm the removal.
 
 

--- a/rpa-manager/modules/ROOT/pages/botmanagement-support.adoc
+++ b/rpa-manager/modules/ROOT/pages/botmanagement-support.adoc
@@ -21,20 +21,31 @@ If a bot only needs to work at specific times, you assign it service times.
 
 == Manage API Keys
 
-An API key is required during installation of a bot. The bot connects to RPA Manager with its API key.
+An API key is required during installation of a bot. The bot connects to RPA Manager with its API key. For security reasons, RPA Manager shows the API Key only during creation. Copy your API Key and save it to a secure place. If you lose an API Key, create a new one.
 
 === Create an API Key
 
-Create a new API key for each bot before installation.
+Create a new API key for each bot before installation or when you lose access to one.
 
-. In the *API Key* view of the *Bot Management* module, click *Create*.
+To create an API key:
+
+. Open the *API Key* view of the *Bot Management* module.
+. Click *New API Key*.
 . In the window *Create Bot API Key*, enter a name and description and click *OK*.
+. In the window *Key Created!*, click *Copy to clipboard*.
+. Copy the API key to a secure place.
+. Click *Close*.
+
+Copy your saved API key into the configuration settings of the bot during installation. You can change the bot API Key with RPA Bot Configurator. 
 
 === Edit an API Key
 
-Edit an API key to change its name or description.
+Edit an API key to change its name or description. If you lose an API key, create a new one.
 
-. In the *API Key* view of the *Bot Management* module, click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the table row of the API key to edit.
+To edit an API key:
+
+. Open the *API Key* view of the *Bot Management* module.
+. Click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the table row of the API key to edit.
 . In the window *Edit Bot API Key*, change name or description and click *OK*.
 
 === Remove an API Key
@@ -43,14 +54,11 @@ Remove API keys you no longer need.
 
 When you delete an API key, the system does not check whether the key is assigned to a bot. If you have deleted an API key that is in use, the bot can no longer connect to RPA Manager until a new API key is assigned.
 
-. In the *API Key* view of the *Bot Management* module, click the *Remove* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the table row of the API key to remove.
+To delete an API key:
+
+. Open the *API Key* view of the *Bot Management* module.
+. Click the *Remove* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the table row of the API key to remove.
 . Confirm the removal.
-
-=== Copy an API Key to the Clipboard
-
-Copy an API key to the clipboard to paste it into the according field during installation or configuration of a bot.
-
-. In the *API Key* view of the *Bot Management* module, click the *Copy* icon image:copy-to-clipboard-icon.png["sheet-on-clipboard symbol",1.5%,1.5%] in the column *API Key* in the table row of the API key you want to copy to the clipboard.
 
 == Manage Service Times
 
@@ -109,10 +117,6 @@ The deleted service time is also removed from the service times of a bot. If the
 
 == See Also
 
-* xref:botmanagement-overview.adoc[Bot Management]
-//* xref::botmanagement-support.adoc[Supporting Bots]
-* xref::botmanagement-know.adoc[Getting to Know Bots]
-* xref::botmanagement-manage.adoc[Managing Bots]
-* xref::botmanagement-troubleshoot.adoc[Troubleshooting Bots]
-
-* xref::processautomation-deploy.adoc[Deploying Automations]
+* xref:rpa-bot::installation.adoc[RPA Bot Installation]
+* xref:rpa-bot::configuration.adoc[RPA Bot Configuration]
+* xref:processautomation-deploy.adoc[Deploying Automations]

--- a/rpa-manager/modules/ROOT/pages/botmanagement-troubleshoot.adoc
+++ b/rpa-manager/modules/ROOT/pages/botmanagement-troubleshoot.adoc
@@ -57,7 +57,7 @@ This option is only available when the bot has the status OK.
 
 An IT administrator can configure the content of the package in the RPA Bot Configurator on the computer where the bot is installed.
 
-. In the *Bots* view of the *Bot Management* module, click the *Download Logfiles* icon in the table row of the bot whose log files you want to read.
+. In the *Bots* view of the *Bot Management* module, click the *Download Logfiles* icon in the row of the bot whose log files you want to read.
 . Extract the contents and view the relevant files.
 
 == Restart a Bot
@@ -72,11 +72,11 @@ In rare cases, an individual thread could have an error due to unforeseen circum
 
 The latter might be the case when the bot has the status OK and a deployed process is within an effective runtime interval, but no process has been started for several minutes.
 
-When you restart the bot, the bot and all of its threads are initially stopped after the pending tasks have been completed. The subsequent restart is then performed in a clean environment, which means the problem should no longer occur.
+When you restart the bot, the bot and all of its threads are initially stopped after the pending tasks have been completed. The restart is then performed in a clean environment, which means the problem should no longer occur.
 
-Restarting a bot will only work if that bot has the status OK. Otherwise it is placed in the task list and is executed as soon as the bot is OK again.
+Restarting a bot only works if that bot has the status OK. Otherwise it is placed in the task list and is executed as soon as the bot is OK again.
 
-. In the *Bots* view of the *Bot Management* module, click the *Restart* icon in the table row of the bot you want to restart.
+. In the *Bots* view of the *Bot Management* module, click the *Restart* icon in the row of the bot you want to restart.
 . Wait a few seconds and refresh the browser to see the effect.
 
 

--- a/rpa-manager/modules/ROOT/pages/dashboard-assemble.adoc
+++ b/rpa-manager/modules/ROOT/pages/dashboard-assemble.adoc
@@ -19,4 +19,4 @@ Create a dashboard that shows you the progress of your automation management wit
 
 Publish a Dashboard to share it with your colleagues. Published dashboards are copied and not synched with the private dashboards they are derived from.
 
- . In the *Private Dashboard* view of the *Dashboard* module, click the *Publish* icon in the table row of the dashboard you want to publish.
+ . In the *Private Dashboard* view of the *Dashboard* module, click the *Publish* icon in the row of the dashboard you want to publish.

--- a/rpa-manager/modules/ROOT/pages/myrpa-handle.adoc
+++ b/rpa-manager/modules/ROOT/pages/myrpa-handle.adoc
@@ -15,13 +15,13 @@ If, during execution of a process, the bot comes across a user task, it shows th
 
 Claim a user task to reserve processing of the user task for yourself. The user task is then moved to your personal task list in the *My User Tasks* view.
 
-. In the *Team Tasks* view of the *My RPA* module, click *Claim Task* in the table row of the task you want to process.
+. In the *Team Tasks* view of the *My RPA* module, click *Claim Task* in the row of the task you want to process.
 
 == Process a User Task
 
 Open a user task and review or change its data to continue the process. After you complete the task, the bot carries on.
 
-. In the *My User Tasks* view of the *My RPA* module, click *Open Task* in the table row of the task you want to process.
+. In the *My User Tasks* view of the *My RPA* module, click *Open Task* in the row of the task you want to process.
 . Review the data.
 . Input or change data if necessary.
 . Click *Finish*.

--- a/rpa-manager/modules/ROOT/pages/processautomation-prepare-deployment-credential.adoc
+++ b/rpa-manager/modules/ROOT/pages/processautomation-prepare-deployment-credential.adoc
@@ -147,7 +147,7 @@ Before editing a credential, check its usage to avoid inadvertent side effects. 
 To check the usage of a credential:
 
 . Open the *Credential Pool* view of the *Process Automation* module.
-. Click the *Usage* icon image:usage-icon.png[binoculars symbol,1.5%,1.5%] in the table row of the credential to check.
+. Click the *Usage* icon image:usage-icon.png[binoculars symbol,1.5%,1.5%] in the row of the credential to check.
 
 A window with a table shows you the configurations that use the credential.
 
@@ -158,7 +158,7 @@ Edit a credential to change its data. You cannot change the type of a credential
 Check the usage of the credential first to avoid inadvertent side effects:
 
 . Open the *Credential Pool* view of the *Process Automation* module.
-. Click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the table row of the credential to edit.
+. Click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the row of the credential to edit.
 . Change data in the *Edit the Credential* form.
 +
 For an explanation of the properties, see <<form-create-credential, *Create a Credential*>>.
@@ -173,7 +173,7 @@ Delete credentials that are no longer needed. You cannot delete credentials link
 To delete a credential:
 
 . Open the *Credential Pool* view of the *Process Automation* module.
-. Click the *Delete* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the table row of the credential to delete.
+. Click the *Delete* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the row of the credential to delete.
 . Confirm the deletion.
 
 == See Also

--- a/rpa-manager/modules/ROOT/pages/processautomation-prepare-deployment-variable.adoc
+++ b/rpa-manager/modules/ROOT/pages/processautomation-prepare-deployment-variable.adoc
@@ -96,7 +96,7 @@ You can only enter values of the specified type.
 Before editing a global variable, check its usage to avoid inadvertent side effects:
 
 . Open the *Global Variables* view of the *Process Automation* module.
-. Click the *Usage* icon image:usage-icon.png[binoculars symbol,1.5%,1.5%] in the table row of the global variable to check.
+. Click the *Usage* icon image:usage-icon.png[binoculars symbol,1.5%,1.5%] in the row of the global variable to check.
 
 A window with a table shows you the configurations that use the global variable.
 
@@ -107,7 +107,7 @@ Edit a global variable to change its name or value. You cannot change the type o
 To edit a global variable:
 
 . Open the *Global Variables* view of the *Process Automation* module.
-. Click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the table row of the global variable to edit.
+. Click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the row of the global variable to edit.
 . Change data in the *Edit the Global Variable* form.
 +
 For an explanation of the properties, see  <<form-create-globalvariable, *Create a Global Variable*>>.
@@ -122,7 +122,7 @@ Delete global variables that are no longer needed. You cannot delete variables l
 To delete a global variable:
 
 . Open the *Global Variables* view of the *Process Automation* module.
-. Click the *Delete* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the table row of the global variable to delete.
+. Click the *Delete* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the row of the global variable to delete.
 . Confirm the deletion.
 
 == See Also

--- a/rpa-manager/modules/ROOT/pages/processevaluation-approve.adoc
+++ b/rpa-manager/modules/ROOT/pages/processevaluation-approve.adoc
@@ -36,7 +36,7 @@ Approve the selected process to refer it to a project manager or a center of exc
 
 After approval, the process is also displayed either in the personal backlog of the project manager (*My RPA* - *My Backlog*) or in the team backlog of the center of excellence (*My RPA* - *Team Backlog*).
 
-. In the *Process Evaluation* view of the *Process Evaluation* module, click *Approve* in the table row of the evaluation you want to approve.
+. In the *Process Evaluation* view of the *Process Evaluation* module, click *Approve* in the row of the evaluation you want to approve.
 . Choose a user or a center of excellence as *Project Manager*.
 . Click *OK*.
 

--- a/rpa-manager/modules/ROOT/pages/processevaluation-configure.adoc
+++ b/rpa-manager/modules/ROOT/pages/processevaluation-configure.adoc
@@ -57,7 +57,7 @@ Edit criteria to make it more useful.
 RPA Manager does not change process evaluations that are based on a template with edited criterion. The evaluations continue to contain the criterion in its original form.
 The changed form of the criterion is used in the templates as soon as the changes are saved.
 
-. In the *Evaluation Criteria* view of the *Process Evaluation* module, click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the table row of the criterion to edit.
+. In the *Evaluation Criteria* view of the *Process Evaluation* module, click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the row of the criterion to edit.
 . Edit the form *Edit <criterion type>*.
 . Click *Save*.
 
@@ -67,7 +67,7 @@ Remove criteria you no longer use.
 
 Process evaluations that have been created before are not changed and continue to contain the criterion even after it is removed.
 
-. In the *Evaluation Criteria* view of the *Process Evaluation* module, click the *Remove* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the table row of the criterion to delete.
+. In the *Evaluation Criteria* view of the *Process Evaluation* module, click the *Remove* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the row of the criterion to delete.
 . Confirm the removal of the criterion from the templates it is used in.
 
 == Manage Process Evaluation Templates
@@ -96,7 +96,7 @@ Select the checkbox to exclude the MuleSoft default criteria from the selection 
 
 Copy and edit templates instead to save time.
 
-. In the *Evaluation Templates* view of the *Process Evaluation* module, click the *Copy* icon image:copy-icon.png["copy symbol",1.5%,1.5%] in the table row of the template you want to copy.
+. In the *Evaluation Templates* view of the *Process Evaluation* module, click the *Copy* icon image:copy-icon.png["copy symbol",1.5%,1.5%] in the row of the template you want to copy.
 . Edit the form *Copy an Evaluation Template*.
 . Click *Save*.
 
@@ -104,7 +104,7 @@ Copy and edit templates instead to save time.
 
 Edit templates to make them more useful.
 
-. In the *Evaluation Templates* view of the *Process Evaluation* module, click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the table row of the template to edit.
+. In the *Evaluation Templates* view of the *Process Evaluation* module, click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the row of the template to edit.
 . Edit the form *Edit an Evaluation Template*.
 . Click *Save*.
 
@@ -114,7 +114,7 @@ Remove templates you no longer use.
 
 Evaluations of a process that use a removed template are not changed.
 
-. In the *Evaluation Templates* view of the *Process Evaluation* module, click the *Remove* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the table row of the template to delete.
+. In the *Evaluation Templates* view of the *Process Evaluation* module, click the *Remove* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the row of the template to delete.
 . Confirm the removal of the template.
 
 == See Also

--- a/rpa-manager/modules/ROOT/pages/processevaluation-propose.adoc
+++ b/rpa-manager/modules/ROOT/pages/processevaluation-propose.adoc
@@ -64,7 +64,7 @@ Drag the slider to the appropriate values. *Exclude* unnecessary criteria.
 
 Edit a process evaluation to correct errors:
 
-. In the *Process Evaluation* view of the *Process Evaluation* module, click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the table row of the evaluation to edit.
+. In the *Process Evaluation* view of the *Process Evaluation* module, click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] in the row of the evaluation to edit.
 . Edit the form *Process Evaluation*.
 . Click *Save*.
 
@@ -72,7 +72,7 @@ Edit a process evaluation to correct errors:
 
 Delete process evaluations that you no longer need:
 
-. In the *Process Evaluation* view of the *Process Evaluation* module, click the *Delete* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the table row of the evaluation to delete.
+. In the *Process Evaluation* view of the *Process Evaluation* module, click the *Delete* icon image:delete-icon.png["trash symbol",1.5%,1.5%] in the row of the evaluation to delete.
 . Confirm the deletion.
 
 == See Also

--- a/rpa-manager/modules/ROOT/pages/processmonitoring-stream.adoc
+++ b/rpa-manager/modules/ROOT/pages/processmonitoring-stream.adoc
@@ -22,7 +22,7 @@ In the *Process Streaming* view, you see the number of configurations, RPA Bots,
 
 Watch the process stream to see what is happening right now.
 
-. In the *Process Streaming* view of the *Process Monitoring* module, click the icon *Show process streams* in the table row of the *Process* you want to watch.
+. In the *Process Streaming* view of the *Process Monitoring* module, click the icon *Show process streams* in the row of the *Process* you want to watch.
 . Toggle *Off / On* to activate and deactivate a stream.
 . Click the *Full Screen* icon in the stream panel to display it in full-screen mode.
 . Press `ESC` to exit full-screen mode and return to the overview page.

--- a/rpa-manager/modules/ROOT/pages/processoperations-financeanalysis-analyze.adoc
+++ b/rpa-manager/modules/ROOT/pages/processoperations-financeanalysis-analyze.adoc
@@ -46,7 +46,7 @@ The changes are shown graphically but are only saved in the detailed view if you
 
 Add new investments as soon as they occur. The initial investment is copied from the process data sheet.
 
-. In the *Finance Analysis* view of the *Process Operations* module, click the icon *Finance Analysis* in the table row of the *Process* you want to add investments to.
+. In the *Finance Analysis* view of the *Process Operations* module, click the icon *Finance Analysis* in the row of the *Process* you want to add investments to.
 . In the panel *Finance Analysis: Cost entries*, click *Add investment*.
 . Complete the form *Finance Analysis: Cost entries*:
 +
@@ -70,7 +70,7 @@ The initial operating costs are copied from the Process data sheet.
 
 Note that any changes to the operating costs shift the date of the break-even point.
 
-. In the *Finance Analysis* view of the *Process Operations* module, click the icon *Finance Analysis* in the table row of the *Process* you want to add investments to.
+. In the *Finance Analysis* view of the *Process Operations* module, click the icon *Finance Analysis* in the row of the *Process* you want to add investments to.
 . In the panel *Finance Analysis: Cost entries*, click *Add change of operating costs*.
 . Complete the form *Finance Analysis: Cost entries*:
 +
@@ -97,7 +97,7 @@ Move the slide control *Months* with the mouse to set the required number of mon
 
 View the graphics *Break-Even Analysis* and *Cost Evaluation*.
 
-. In the *Finance Analysis* view of the *Process Operations* module, click the icon *Finance Analysis* in the table row of the *Process* you want to view.
+. In the *Finance Analysis* view of the *Process Operations* module, click the icon *Finance Analysis* in the row of the *Process* you want to view.
 
 == See Also
 

--- a/rpa-manager/modules/ROOT/pages/processoperations-processexecutionplans.adoc
+++ b/rpa-manager/modules/ROOT/pages/processoperations-processexecutionplans.adoc
@@ -32,7 +32,7 @@ View the execution timetable to see the effective run time of a process.
 
 If there are more sessions assigned than free sessions available, the number of runs of a process within this timeframe depends on its priority.
 
-. In the *Process Execution Plans* view of the *Process Operations* module, click the icon *Execution timetable* in the table row of the process you want to view.
+. In the *Process Execution Plans* view of the *Process Operations* module, click the icon *Execution timetable* in the row of the process you want to view.
 . Click on the Gantt chart of a configuration to view the composition of the effective runtime.
 
 == See Also

--- a/rpa-manager/modules/ROOT/pages/processoperations-upcomingprocesschanges.adoc
+++ b/rpa-manager/modules/ROOT/pages/processoperations-upcomingprocesschanges.adoc
@@ -33,7 +33,7 @@ To view the changes:
 
 . Open the *Upcoming Process Changes* view in the *Process Operations* module.
 . View the descriptions in the table.
-. Click the *Show Changes* icon image:show-icon.png[eye symbol,1.5%,1.5%] in the table row of the edited activity to compare the deployed version with the latest version of that activity.
+. Click the *Show Changes* icon image:show-icon.png[eye symbol,1.5%,1.5%] in the row of the edited activity to compare the deployed version with the latest version of that activity.
 
 [[map-bpmn-elements-to-process-activities]]
 == Map BPMN Elements to Process Activities

--- a/rpa-manager/modules/ROOT/pages/usermanagement-assemble.adoc
+++ b/rpa-manager/modules/ROOT/pages/usermanagement-assemble.adoc
@@ -41,7 +41,7 @@ Click on user names to assign them to or remove them from the user group.
 
 Edit a user group to change its function or members.
 
-. In the *User Groups* view of the *User Management* module, click *Edit* in the table row of the user group to edit.
+. In the *User Groups* view of the *User Management* module, click *Edit* in the row of the user group to edit.
 . Edit the form *Edit User Group*:
 +
 * *Center of excellence*:
@@ -56,8 +56,8 @@ Click on user names to assign them to or remove them from the user group.
 
 Delete user groups no longer needed. Check their usage and reassign their tasks first.
 
-. In the *User Groups* view of the *User Management* module, click the icon *Usage* in the table row of the user group to delete. Proceed only, if the user group is not needed anymore.
-. In the *User Groups* view of the *User Management* module, click *Remove* in the table row of the user group to delete.
+. In the *User Groups* view of the *User Management* module, click the icon *Usage* in the row of the user group to delete. Proceed only, if the user group is not needed anymore.
+. In the *User Groups* view of the *User Management* module, click *Remove* in the row of the user group to delete.
 . Confirm the deletion.
 
 [[designate-user-groups-as-centers-of-excellence]]
@@ -65,7 +65,7 @@ Delete user groups no longer needed. Check their usage and reassign their tasks 
 
 User groups marked as center of excellence may approve processes for automation. You can designate user groups as centers of excellence on creation or edit this property afterwards.
 
-. In the *User Groups* view of the *User Management* module, click *Edit* in the table row of the user group to edit.
+. In the *User Groups* view of the *User Management* module, click *Edit* in the row of the user group to edit.
 . Edit the form *Edit User Group*:
 +
 * *Center of excellence*:

--- a/rpa-manager/modules/ROOT/pages/usermanagement-connect.adoc
+++ b/rpa-manager/modules/ROOT/pages/usermanagement-connect.adoc
@@ -1,4 +1,4 @@
-= Connecting RPA Processes from Salesforce Products
+= Connecting to RPA Processes from Salesforce Products
 
 RPA Manager requires user API keys to integrate RPA processes into other Salesforce products. For example, you can use your API key to configure an RPA connector in a MuleSoft Composer flow.
 

--- a/rpa-manager/modules/ROOT/pages/usermanagement-connect.adoc
+++ b/rpa-manager/modules/ROOT/pages/usermanagement-connect.adoc
@@ -1,4 +1,4 @@
-= Connecting to RPA Manager from Other Salesforce Products
+= Connecting to RPA Manager from Salesforce Products
 
 RPA Manager requires user API keys for the integration of RPA processes into other Salesforce products. For example, use your API key to configure an RPA connector in a MuleSoft Composer flow.
 

--- a/rpa-manager/modules/ROOT/pages/usermanagement-connect.adoc
+++ b/rpa-manager/modules/ROOT/pages/usermanagement-connect.adoc
@@ -1,4 +1,4 @@
-= Connecting to RPA Manager from Salesforce Products
+= Connecting RPA Processes from Salesforce Products
 
 RPA Manager requires user API keys for the integration of RPA processes into other Salesforce products. For example, use your API key to configure an RPA connector in a MuleSoft Composer flow.
 
@@ -71,5 +71,6 @@ To delete a user API key:
 
 == See Also
 
+* xref:processautomation-deploy.adoc#invokable-configuration[Create an Invokable Run Configuration]
 * xref:composer::ms_composer_rpa_reference.adoc[MuleSoft RPA Connector for Composer]
 * https://help.salesforce.com/s/articleView?id=sf.flow_build_use_flows_with_mulesoft_rpa.htm&type=5[Salesforce: Use Flows with MuleSoft RPA^]

--- a/rpa-manager/modules/ROOT/pages/usermanagement-connect.adoc
+++ b/rpa-manager/modules/ROOT/pages/usermanagement-connect.adoc
@@ -1,6 +1,6 @@
 = Connecting RPA Processes from Salesforce Products
 
-RPA Manager requires user API keys for the integration of RPA processes into other Salesforce products. For example, use your API key to configure an RPA connector in a MuleSoft Composer flow.
+RPA Manager requires user API keys to integrate RPA processes into other Salesforce products. For example, you can use your API key to configure an RPA connector in a MuleSoft Composer flow.
 
 For security reasons, you can only see and copy your API key on creation.
 
@@ -26,7 +26,7 @@ For security reasons, you can only see and copy your API key on creation.
 [[create-an-api-key-for-a-user]]
 == Create a User API Key
 
-Create an API key for yourself to integrate an RPA process into another Salesforce product. After expiration the integrated process instance can no longer connect to RPA Manager from other Salesforce products. Edit the API key to move the expiration date. For security reasons, RPA Manager shows the API Key only during creation. Copy your API Key and save it to a secure place. If you lose an API Key, create a new one.
+Create an API key for yourself to integrate an RPA process into another Salesforce product. After expiration, the integrated process instance can no longer connect to RPA Manager from other Salesforce products. Edit the API key to move the expiration date. For security reasons, RPA Manager shows the API Key only during creation. Copy your API Key and save it to a secure place. If you lose an API Key, create a new one.
 
 To create a user API key: 
 
@@ -35,7 +35,7 @@ To create a user API key:
 . [[form-createuserapikey]] Complete the form *Create User API Key*:
 * *User*:
 +
-Select yourself. Your identity and permissions are used for the connection from another Salesforce product to RPA Manager.
+Select yourself. Your identity and permissions are used to connect from another Salesforce products to RPA Manager.
 * *Expiration Date*:
 +
 Select an expiration date for the user API key from the calendar.
@@ -44,7 +44,7 @@ Select an expiration date for the user API key from the calendar.
 . Copy the API key to a secure place.
 . Click *Close*.
 
-Copy your saved API key into the configuration settings of the Salesforce products you want to integrate the RPA processes.
+Copy your saved API key into the configuration settings of the Salesforce products into which you want to integrate the RPA processes.
 
 == Edit a User API Key
 
@@ -61,7 +61,7 @@ For an explanation of the properties, see <<form-createuserapikey, *Create a Use
 
 == Delete a User API Key
 
-Delete a user API key to revoke REST API access to RPA Manager from the user. Integrated processes using the deleted API key stop working.
+Delete a user API key to revoke the user's REST API access to RPA Manager. Integrated processes that use the deleted API key stop working.
 
 To delete a user API key:
 

--- a/rpa-manager/modules/ROOT/pages/usermanagement-connect.adoc
+++ b/rpa-manager/modules/ROOT/pages/usermanagement-connect.adoc
@@ -1,6 +1,8 @@
-= Connecting to MuleSoft Composer
+= Connecting to RPA Manager from Other Salesforce Products
 
-User API keys are required for the integration of RPA processes in a MuleSoft Composer flow. Use your API key to configure an API connector in MuleSoft Composer.
+RPA Manager requires user API keys for the integration of RPA processes into other Salesforce products. For example, use your API key to configure an RPA connector in a MuleSoft Composer flow.
+
+For security reasons, you can only see and copy your API key on creation.
 
 == Before You Begin
 
@@ -13,35 +15,61 @@ User API keys are required for the integration of RPA processes in a MuleSoft Co
 |Open the *User Management* module
 |User Management Open
 
-|Create, edit, license, and delete users
-|User Management Administration
-
 |Create, edit, and delete API keys
 |User API Key Create, User API Key Edit, User API Key Delete
 
 |===
 
-* The user who uses an API key must exist in the *Users* view of the *User Management* module.
+* You must have an account in RPA Manager to associate your API key with.
+* You must have a secure place accessible to store your API key.
 
 [[create-an-api-key-for-a-user]]
-== Create an API Key for a User
+== Create a User API Key
 
-Create an API key for a user to configure an API connector in MuleSoft Composer. After the expiration date the user can no longer connect to RPA Manager via Composer. The expiration date can be moved.
+Create an API key for yourself to integrate an RPA process into another Salesforce product. After expiration the integrated process instance can no longer connect to RPA Manager from other Salesforce products. Edit the API key to move the expiration date. For security reasons, RPA Manager shows the API Key only during creation. Copy your API Key and save it to a secure place. If you lose an API Key, create a new one.
 
-. In the *User API Keys* view of the *User Management* module, click *Create*.
-. . Complete the form *Create User API Key*:
+To create a user API key: 
+
+. Open the *User API Keys* view of the *User Management* module.
+. Click *Create*.
+. [[form-createuserapikey]] Complete the form *Create User API Key*:
+* *User*:
++
+Select yourself. Your identity and permissions are used for the connection from another Salesforce product to RPA Manager.
 * *Expiration Date*:
 +
 Select an expiration date for the user API key from the calendar.
 . Click *OK*.
+. In the window *Key Created!*, click *Copy to clipboard*.
+. Copy the API key to a secure place.
+. Click *Close*.
 
-== Copy an API Key to the Clipboard
+Copy your saved API key into the configuration settings of the Salesforce products you want to integrate the RPA processes.
 
-Copy an API key to the clipboard to paste it into the configuration of an API connector in MuleSoft Composer.
+== Edit a User API Key
 
-. In the *User API Keys* view of the *User Management* module, click the *Copy to clipboard* icon image:copy-to-clipboard-icon.png["sheet-on-clipboard symbol",1.5%,1.5%] in the table row of the user API key you want to use.
+Edit a user API key to change its name, description, or expiration date. If you lost access to your API key, create a new one.
+
+To edit a user API key:
+
+. Open the *User API Keys* view of the *User Management* module.
+. Click the *Edit* icon image:edit-icon.png["pen-to-paper symbol",1.5%,1.5%] on the panel of the user API key to edit.
+. Edit the form *Create User API Key*:
++
+For an explanation of the properties, see <<form-createuserapikey, *Create a User API Key*>>.
+. Click *Save*.
+
+== Delete a User API Key
+
+Delete a user API key to revoke REST API access to RPA Manager from the user. Integrated processes using the deleted API key stop working.
+
+To delete a user API key:
+
+. Open the *User API Keys* view of the *User Management* module.
+. Click the *Remove* icon image:delete-icon.png["trash can symbol",1.5%,1.5%] on the panel of the user API key to remove.
+. Confirm the removal.
 
 == See Also
 
 * xref:composer::ms_composer_rpa_reference.adoc[MuleSoft RPA Connector for Composer]
-//* https://help.salesforce.com/s/articleView?id=sf.ms_composer_rpa_reference.htm&type=5[MuleSoft Composer for Salesforce RPA Connector^]
+* https://help.salesforce.com/s/articleView?id=sf.flow_build_use_flows_with_mulesoft_rpa.htm&type=5[Salesforce: Use Flows with MuleSoft RPA^]


### PR DESCRIPTION
User and bot API keys are no longer visible after creation. They need to be copied during creation.
-> Adapted and enhanced the docs.