### PR TITLE
W-14117637-reworkiambanners-se

### DIFF
--- a/rpa-home/modules/ROOT/nav.adoc
+++ b/rpa-home/modules/ROOT/nav.adoc
@@ -1,7 +1,7 @@
 .xref:index.adoc[RPA]
 * xref:index.adoc[RPA Overview]
 * xref:release-notes.adoc[Release Notes] 
-* xref:anypoint-migration-overview.adoc[Anypoint Platform Migration Overview]
+* xref:anypoint-migration-overview.adoc[Anypoint Platform Integration Overview]
 * xref:hardware-software-requirements.adoc[Hardware and Software Requirements]
 * xref:ms-automation-credits-usage-types.adoc[]
 ** xref:ms-automation-credits-2.adoc[]

--- a/rpa-home/modules/ROOT/pages/anypoint-migration-overview.adoc
+++ b/rpa-home/modules/ROOT/pages/anypoint-migration-overview.adoc
@@ -17,7 +17,9 @@ After your organization is integrated into Anypoint Platform:
 * Administrators configure RPA users, teams, and permissions using Access Management instead of the *User Management* module in RPA Manager.
 * RPA Manager deprecates roles and user groups and starts using teams from Anypoint Platform instead. 
 * RPA Manager supports using Connected Apps to connect with Anypoint Platform, which provides a more secure and improved authentication mechanism than API keys. 
-* RPA Manager supports deleting users who have assigned processes and reassigning those processes to other users or teams. 
+* RPA Manager supports deleting users who have assigned processes and reassigning those processes to other users or teams.
++
+See xref:rpa-manager::settings-adminsettings-reassignassets.adoc[] for instructions.
 * For non-federated orgs, MuleSoft automatically creates teams in Anypoint Platform to match the existing roles and user groups in RPA Manager: 
 +
 Team names are restricted to alphanumeric characters, hyphens, underscores, and spaces. If your role or user group contains unsupported characters, these characters are omitted when creating the new team name.

--- a/rpa-home/modules/ROOT/pages/anypoint-migration-overview.adoc
+++ b/rpa-home/modules/ROOT/pages/anypoint-migration-overview.adoc
@@ -1,4 +1,4 @@
-= Anypoint Platform Migration Overview
+= Anypoint Platform Integration Overview
 
 On July 26th, 2023 MuleSoft RPA integrated with Anypoint Platform to unify the login experience and support external identity providers (IdP). All new customers that bought the MuleSoft Automation bundle after this date are ready to take advantage of all the new features and improvements from the integration. The migration process does not affect new customers.
 
@@ -11,7 +11,7 @@ For additional questions, contact us at rpa_migration_support@salesforce.com.
 
 == Summary of Changes
 
-After your organization is migrated to Anypoint Platform:  
+After your organization is integrated into Anypoint Platform:  
 
 * Users log in to RPA Manager, RPA Builder, and RPA Recorder using their Anypoint Platform account. 
 * Administrators configure RPA users, teams, and permissions using Access Management instead of the *User Management* module in RPA Manager.

--- a/rpa-manager/modules/ROOT/pages/botmanagement-troubleshoot.adoc
+++ b/rpa-manager/modules/ROOT/pages/botmanagement-troubleshoot.adoc
@@ -80,7 +80,7 @@ An IT administrator can configure the content of the package in the RPA Bot Conf
 
 == Turn On Debug Logging
 
-Debug Logging is supported by RPA Bots with version 1.3.3 and later.
+Debug Logging is supported by RPA Bots with version 1.3.4 and later.
 
 If a process execution fails when a bot runs correctly, turn on debug logging for at least the time span of the next process run to get help detecting the cause.
 

--- a/rpa-manager/modules/ROOT/pages/index.adoc
+++ b/rpa-manager/modules/ROOT/pages/index.adoc
@@ -1,5 +1,6 @@
 = RPA Manager Overview
-:page-notice-banner-message: MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdPs). After your organization migrates to Anypoint Platform, the Settings module replaces the Organization Management module and the User Management module is removed.
+
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
 
 RPA Manager is the cloud-based control plane for the automations that is integrated into Anypoint Platform.
 
@@ -17,7 +18,7 @@ Ensure that access to this URL is possible from your organization.
 
 RPA Builder, RPA Bot, and RPA Recorder use this URL to connect to your RPA Manager instance.
 
-== IAM Migration
+== Anypoint Platform Migration
 
 MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdPs). 
 

--- a/rpa-manager/modules/ROOT/pages/index.adoc
+++ b/rpa-manager/modules/ROOT/pages/index.adoc
@@ -29,7 +29,7 @@ If you are unsure whether your org is integrated, open the *Home* module in RPA 
 * If you are using an RPA account for login, there is a quick link to Composer:
 + 
 image:rpa-manager-home-premigration.png[Screenshot of the Composer quick link panel in the Home module of RPA Manager,25%,25%]
-* If you are using an Anypoint account for login,, there is a quick link to Access Management:
+* If you are using an Anypoint account for login, there is a quick link to Access Management:
 +
 image:rpa-manager-home-postmigration.png[Screenshot of the Composer quick link panel in the Home module of RPA Manager,25%,25%]
 

--- a/rpa-manager/modules/ROOT/pages/index.adoc
+++ b/rpa-manager/modules/ROOT/pages/index.adoc
@@ -18,23 +18,23 @@ Ensure that access to this URL is possible from your organization.
 
 RPA Builder, RPA Bot, and RPA Recorder use this URL to connect to your RPA Manager instance.
 
-== Anypoint Platform Migration
+== Anypoint Platform Integration
 
 MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdPs). 
 
-Refer to xref:rpa-home::anypoint-migration-overview.adoc[Anypoint Platform Migration Overview] for an overview of the changes and requirements.
+Refer to xref:rpa-home::anypoint-migration-overview.adoc[Anypoint Platform Integration Overview] for an overview of the changes and requirements.
 
-If you are unsure whether your org is migrated, open the *Home* module in RPA Manager:
+If you are unsure whether your org is integrated, open the *Home* module in RPA Manager:
 
-* Pre-migration, there is a quick link to Composer:
+* If you are using an RPA account for login, there is a quick link to Composer:
 + 
 image:rpa-manager-home-premigration.png[Screenshot of the Composer quick link panel in the Home module of RPA Manager,25%,25%]
-* Post-migration, there is a quick link to Access Management:
+* If you are using an Anypoint account for login,, there is a quick link to Access Management:
 +
 image:rpa-manager-home-postmigration.png[Screenshot of the Composer quick link panel in the Home module of RPA Manager,25%,25%]
 
 == See Also
 
-* xref:rpa-home::anypoint-migration-overview.adoc[Anypoint Platform Migration Overview]
+* xref:rpa-home::anypoint-migration-overview.adoc[Anypoint Platform Integration Overview]
 * https://docs.mulesoft.com/access-management/[Access Management]
 * xref:usermanagement-manage.adoc#iforgotmypassword[What to Do if You Forgot Your Password]

--- a/rpa-manager/modules/ROOT/pages/organizationmanagement-overview.adoc
+++ b/rpa-manager/modules/ROOT/pages/organizationmanagement-overview.adoc
@@ -1,4 +1,7 @@
 = Organization Management Overview
-:page-notice-banner-message: MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdPs). After your organization migrates to Anypoint Platform, the Settings module replaces the Organization Management module.
 
-The *Organization Management* module enables you to configure the currency and decimal sign to show in RPA Manager modules and configure your Anypoint Platform credentials, which enables you to publish a process automation to Anypoint Exchange.
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
+
+If you use an Anypoint account to login to RPA Manager, refer to the xref:settings-overview.adoc[*Settings* documentation].
+
+If you use an RPA account to login to RPA Manager, the *Organization Management* module enables you to configure the currency and decimal sign to show in RPA Manager modules and configure your Anypoint Platform credentials, which enables you to publish a process automation to Anypoint Exchange.

--- a/rpa-manager/modules/ROOT/pages/organizationmanagement-settings.adoc
+++ b/rpa-manager/modules/ROOT/pages/organizationmanagement-settings.adoc
@@ -1,22 +1,23 @@
 = Configure Organization Settings
-:page-notice-banner-message: MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdPs). After your organization migrates to Anypoint Platform, the Settings module replaces the Organization Management module.
 
-The *Settings* view enables you to configure the currency and decimal sign to show in RPA Manager modules and configure your Anypoint Platform credentials, which enables you to publish a process automation to Anypoint Exchange.
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
+
+If you use an Anypoint account to login to RPA Manager, refer to the xref:settings-overview.adoc[*Settings* documentation].
+
+If you use an RPA account to login to RPA Manager, the *Settings* view enables you to configure the currency and decimal sign to show in RPA Manager modules and configure your Anypoint Platform credentials, which enables you to publish a process automation to Anypoint Exchange.
 
 == Before You Begin
 
-* Ask an organization administrator in Access Management to assign you the required permissions:
+* Ask an administrator to assign you the required privileges:
 +
-[cols="1,1,1"]
+[cols="2,1"]
 |===
-|*Action* |*RPA Permission* | *Deprecated RPA Permission*
+|*Action* |*Privilege*
 
 |View configured settings for your organization
-|RPA Administrator
 |Organization Management Open
 
 |Add or modify settings for your organization
-|RPA Administrator
 |Organization Management Administration
 |===
 

--- a/rpa-manager/modules/ROOT/pages/processautomation-prepare-deployment-credential.adoc
+++ b/rpa-manager/modules/ROOT/pages/processautomation-prepare-deployment-credential.adoc
@@ -1,5 +1,6 @@
 = Manage Credentials
-:page-notice-banner-message: MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdPs). After your organization migrates to Anypoint Platform, user groups are replaced by teams. 
+
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
 
 Credentials store login data for external applications or web services. By using a credential, a bot can log in to an application during process runs. Passwords are encrypted. Only affiliated users can view, edit, and use the credentials.
 
@@ -73,7 +74,9 @@ To create a credential:
 Select users that may view, edit, and use the credential. Add yourself so that you can also view, edit, and use the credential.
 * *User group affiliation*
 +
-Select user groups whose members may view, edit, and use the credential.
+Select user groups whose members may view, edit, and use the credential. 
++
+If you use an Anypoint account to login to RPA Manager, user groups are replaced by teams.
 * *Phase affiliation*
 +
 Phases in which the credential can be deployed. When you create or change the credential, your privileges determine which phases the user can select:
@@ -188,3 +191,4 @@ To delete a credential:
 * xref:processautomation-deploy.adoc#production-configuration-link-globals[Linkable Activity Parameters in Production Configurations]
 * xref:processautomation-deploy.adoc#invokable-configuration-link-globals[Linkable Activity Parameters in Invokable Configurations]
 * xref:rpa-home::automation-userrolesandpermissions.adoc[User Roles and Permissions]
+* xref:usermanagement-assemble.adoc[Assembling User Groups]

--- a/rpa-manager/modules/ROOT/pages/processevaluation-approve.adoc
+++ b/rpa-manager/modules/ROOT/pages/processevaluation-approve.adoc
@@ -1,5 +1,6 @@
 = Approving a Process for Automation
-:page-notice-banner-message: MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdPs). After your organization migrates to Anypoint Platform, user groups are replaced by teams and the Center of Excellence flag is deprecated. Ensure that the team you refer a process to has the required RPA permissions for automating the process. 
+
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
 
 You approve an evaluated process candidate to refer it to a project manager or a center of excellence for automation.
 
@@ -23,6 +24,8 @@ You approve an evaluated process candidate to refer it to a project manager or a
 
 * You can only approve evaluated process candidates.
 * You can only refer processes to users assigned the `Project Management` privilege or user groups assigned as `Center of Excellence`. 
++
+If you use an Anypoint account to login to RPA Manager, user groups are replaced by teams and the Center of Excellence flag is deprecated. Ensure that the team you refer a process to has the required RPA permissions for automating the process. 
 
 == Select a Process for Approval
 

--- a/rpa-manager/modules/ROOT/pages/processmonitoring-queue.adoc
+++ b/rpa-manager/modules/ROOT/pages/processmonitoring-queue.adoc
@@ -14,7 +14,7 @@ The processes are executed in the following order:
 . Test configurations
 . Production configurations in ascending order of their assigned priority numbers
 
-If two or more configurations have the same priority, the ones deployed first are execute first.
+If two or more configurations have the same priority, the ones deployed first are executed first.
 
 == View the Queue
 

--- a/rpa-manager/modules/ROOT/pages/settings-adminsettings-general.adoc
+++ b/rpa-manager/modules/ROOT/pages/settings-adminsettings-general.adoc
@@ -1,5 +1,8 @@
 = Configure General Settings
-:page-notice-banner-message: MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdPs). After your organization migrates to Anypoint Platform, the Settings module replaces the Organization Management module.
+
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
+
+If you use an RPA account to login to RPA Manager, refer to the xref:organizationmanagement-settings.adoc#configure-currency-and-decimal-sign[*Organization Management* documentation].
 
 The *General* tab in the *Admin Settings* view enables you to configure the currency and decimal sign to show in RPA Manager modules.
 

--- a/rpa-manager/modules/ROOT/pages/settings-adminsettings-overview.adoc
+++ b/rpa-manager/modules/ROOT/pages/settings-adminsettings-overview.adoc
@@ -1,5 +1,8 @@
 = Admin Settings Overview
-:page-notice-banner-message: MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdPs). After your organization migrates to Anypoint Platform, the Settings module replaces the Organization Management module.
+
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
+
+If you use an RPA account to login to RPA Manager, refer to the xref:organizationmanagement-overview.adoc[*Organization Management* documentation].
 
 The *Admin Settings View* of the *Settings* module enables you to do the following:
 

--- a/rpa-manager/modules/ROOT/pages/settings-adminsettings-reassignassets.adoc
+++ b/rpa-manager/modules/ROOT/pages/settings-adminsettings-reassignassets.adoc
@@ -1,5 +1,7 @@
 = Reassigning RPA Assets
 
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
+
 If an RPA user or team is deleted or disabled in Access Management, the *Reassign Assets* tab in the *Admin Settings* view of the *Settings* module shows RPA assets that were assigned to this user or team.
 
 All users with the *Reassign Users* or *RPA Administrator* permission get an email when an RPA asset is orphaned because its last assigned user is deleted.

--- a/rpa-manager/modules/ROOT/pages/settings-connect.adoc
+++ b/rpa-manager/modules/ROOT/pages/settings-connect.adoc
@@ -1,9 +1,15 @@
 = Connecting to RPA Processes from Salesforce Products
-:page-notice-banner-message: You can now use Connected Apps for a more secure and scalable authentication method than User API Keys.
 
-RPA Manager requires authentication to integrate RPA processes into other Salesforce products. For example, you can use your API key to configure an RPA connector in a MuleSoft Composer flow.
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
+
+RPA Manager requires user authentication to integrate RPA processes into other Salesforce products. For example, you can use your API key to configure an RPA connector in a MuleSoft Composer flow.
+
+If you use an RPA account to login to RPA Manager, refer to the xref:usermanagement-connect.adoc[*User Management* documentation].
 
 For security reasons, you can only see and copy an API key on creation.
+
+[TIP]
+You can now use https://docs.mulesoft.com/access-management/connected-apps-overview[Connected Apps] for a more secure and scalable authentication method than User API Keys.
 
 == Before You Begin
 

--- a/rpa-manager/modules/ROOT/pages/settings-overview.adoc
+++ b/rpa-manager/modules/ROOT/pages/settings-overview.adoc
@@ -1,5 +1,8 @@
 = Settings Overview
-:page-notice-banner-message: MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdPs). After your organization migrates to Anypoint Platform, the Settings module replaces the Organization Management module.
+
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
+
+If you use an RPA account to login to RPA Manager, refer to the xref:organizationmanagement-overview.adoc[*Organization Management* documentation].
 
 The *Settings* module enables you to do the following:
 

--- a/rpa-manager/modules/ROOT/pages/usermanagement-assemble.adoc
+++ b/rpa-manager/modules/ROOT/pages/usermanagement-assemble.adoc
@@ -1,7 +1,10 @@
 = Assembling User Groups
-:page-notice-banner-message: MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdP). After your organization is migrated to Anypoint Platform, the User Management module is removed and Anypoint teams replace the RPA Manager user groups. To function as a center of excellence for approving processes for automation or to complete user tasks, the teams must have the required RPA permissions.
+
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
 
 In automation projects, several employees often work together on one task. These users can be assigned to user groups. User groups can be deployed for processing of user tasks during execution of a process. User groups marked as center of excellence may approve processes for automation.
+
+If you use an Anypoint account to login to RPA Manager, Anypoint teams replace the RPA Manager user groups. To function as a center of excellence for approving processes for automation or to complete user tasks, the teams must have the required RPA permissions. To manage teams, refer to the https://docs.mulesoft.com/access-management/[Anypoint Access Management documentation^].
 
 In the *User Groups* view in the *User Management* module, you can see all existing user groups.
 
@@ -9,18 +12,16 @@ You can create new user groups, check their usage, edit them, and delete them.
 
 == Before You Begin
 
-* Ask an organization administrator in Access Management to assign you the required permissions:
+* Ask an administrator to assign you the required privileges:
 +
-[cols="1,1,1"]
+[cols="2,1"]
 |===
-|*Action* |*RPA Permission* | *Deprecated RPA Permission*
+|*Action* |*Privilege*
 
 |Open the User Management module
-|
 |User Management Open
 
 |Create, edit, and delete user groups.
-|
 |User Group Create, User Group Edit, User Group Delete
 
 |===

--- a/rpa-manager/modules/ROOT/pages/usermanagement-connect.adoc
+++ b/rpa-manager/modules/ROOT/pages/usermanagement-connect.adoc
@@ -1,24 +1,25 @@
 = Connecting to RPA Processes from Salesforce Products
-:page-notice-banner-message: MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdPs). After your organization migrates to Anypoint Platform, the User Management module is removed and the RPA Administrator creates new user API keys in the Settings module.
 
-RPA Manager requires user API keys to integrate RPA processes into other Salesforce products. For example, you can use your API key to configure an RPA connector in a MuleSoft Composer flow.
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
+
+If you use an Anypoint account to login to RPA Manager, refer to the xref:settings-connect.adoc[*Settings* documentation].
+
+RPA Manager requires user authentication to integrate RPA processes into other Salesforce products. For example, you can use your API key to configure an RPA connector in a MuleSoft Composer flow.
 
 For security reasons, you can only see and copy your API key on creation.
 
 == Before You Begin
 
-* Ask an organization administrator in Access Management to assign you the required permissions:
+* Ask an administrator to assign you the required privileges:
 +
-[cols="1,1,1"]
+[cols="2,1"]
 |===
-|*Action* |*RPA Permission* | *Deprecated RPA Permission*
+|*Action* |*Privilege*
 
 |Open the *User Management* module
-|
 |User Management Open
 
 |Create, edit, and delete API keys
-|RPA Administrator
 |User API Key Create, User API Key Edit, User API Key Delete
 
 |===

--- a/rpa-manager/modules/ROOT/pages/usermanagement-manage.adoc
+++ b/rpa-manager/modules/ROOT/pages/usermanagement-manage.adoc
@@ -1,5 +1,11 @@
 = Managing Users
-:page-notice-banner-message: MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdP). After your organization is migrated to Anypoint Platform, the User Management module is removed and the RPA Administrator manages the users in Access Management.
+
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
+
+If you use an Anypoint account to login to RPA Manager, refer to the https://docs.mulesoft.com/access-management/[Anypoint Access Management documentation^].
+
+[IMPORTANT]
+If you are your organization's first admin user, you are responsible for creating all other users. You can do this yourself or create another user with admin privileges to whom you delegate this task.
 
 Manage the users of RPA Manager, RPA Recorder, and RPA Builder:
 
@@ -7,9 +13,6 @@ Manage the users of RPA Manager, RPA Recorder, and RPA Builder:
 * Edit the users' personal data.
 * Assign privileges or roles to users that enable them to work in specific modules and, access RPA Builder and RPA Recorder, and assume responsibility for process projects.
 * Assign a user to a process team.
-
-[IMPORTANT]
-If you are your organization's first admin user, you are responsible for creating all other users. You can do this yourself or create another user with admin privileges to whom you delegate this task.
 
 == Before You Begin
 

--- a/rpa-manager/modules/ROOT/pages/usermanagement-overview.adoc
+++ b/rpa-manager/modules/ROOT/pages/usermanagement-overview.adoc
@@ -1,5 +1,8 @@
 = User Management Overview
-:page-notice-banner-message: MuleSoft RPA is integrating with Anypoint Platform to unify the login experience and provide support for external identity providers (IdP). After your organization is migrated to Anypoint Platform, the User Management module is removed.
+
+include::reuse::partial$rpa/iam-migration-affectedtopic-banner.adoc[]
+
+If you use an Anypoint account to login to RPA Manager, refer to the https://docs.mulesoft.com/access-management/[Anypoint Access Management documentation^].
 
 In the *User Management* module, you manage the users of RPA Manager and RPA Builder:
 


### PR DESCRIPTION
**!!! To be published together with the branch of the same name in docs-reuse !!!** (https://github.com/mulesoft/docs-reuse/pull/21)

Replaced page banner
on RPA Manager Overview
with docs-reuse banner
highlighting RPA topics affected by the Anypoint Platform migration

moved aditional information from previous banners into the text flow.