### PR TITLE
W-15581223-securesessions-noAzureVDI-se

### DIFF
--- a/rpa-bot/1.6/modules/ROOT/pages/_partials/hard-soft-requirements.adoc
+++ b/rpa-bot/1.6/modules/ROOT/pages/_partials/hard-soft-requirements.adoc
@@ -66,6 +66,7 @@ Secure Sessions are hidden Desktop sessions that run in the background and are a
 
 To use Secure Sessions you must ensure that all prerequisites are met and all responsible persons are informed.
 
+* You can't use Secure Sessions with any operating system running on the Microsoft Azure Virtual Desktop Infrastructure (VDI).
 * The RPA Bot service runs under the `Local System` account per default.
 ** To use another account, ensure that it has permission to run Windows services.
 * The RPA Bot service runs processes under user accounts on the same computer or within the same domain.


### PR DESCRIPTION
Added the following info to the RPA Bot System Requirements: 
You can't use Secure Sessions with any operating system running on the Microsoft Azure Virtual Desktop Infrastructure (VDI).